### PR TITLE
Fix output path config

### DIFF
--- a/pcfaggrid.pcfproj
+++ b/pcfaggrid.pcfproj
@@ -10,7 +10,8 @@
   <PropertyGroup>
     <Name>pcfaggrid</Name>
     <ProjectGuid>8a545e68-5993-4791-ae41-67d9338e436c</ProjectGuid>
-    <OutputPath>$(MSBuildThisFileDirectory)out\controls</OutputPath>
+    <!-- Match the output directory defined in pcfconfig.json -->
+    <OutputPath>out/controls</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/pcfconfig.json
+++ b/pcfconfig.json
@@ -1,4 +1,4 @@
 {
-    "outDir": "out/controls/"
+    "outDir": "out/controls"
 }
 


### PR DESCRIPTION
## Summary
- align `pcfconfig.json` with the output path used by MSBuild
- set the same path in `pcfaggrid.pcfproj`

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_b_687fe0d423288333af9b243287e1a35e