### PR TITLE
Allow cellDataType alias for dateTime columns

### DIFF
--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -165,6 +165,11 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
             try {
                 const temp = JSON.parse(columnDefsInput as any);
                 if (Array.isArray(temp)) {
+                    temp.forEach(def => {
+                        if (def && def.cellDataType && !def.dataType) {
+                            def.dataType = def.cellDataType;
+                        }
+                    });
                     parsedDefs = temp;
                 }
             } catch (e) {

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Set the `filter` key to one of AG Grid's built‑in filter names:
 
 Extra configuration can be supplied using `filterParams`.
 
+To edit both date and time values, use `agDateStringCellEditor` and set
+`dataType: 'dateTimeString'` in your column definition. Enable the browser
+date picker with:
+
+```PowerApps
+cellEditorParams: { useBrowserDatePicker: true, inputType: 'datetime-local' }
+```
+
 ### Cell Content
 The grid provides several options for controlling how values are displayed inside each cell:
 


### PR DESCRIPTION
## Summary
- support `cellDataType` as an alias for `dataType` when parsing column definitions
- document how to enable editing of date and time values

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687fe98fe7a48333b278995e6b59de0c