### PR TITLE
Remove seconds from date editors

### DIFF
--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -169,6 +169,19 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                         if (def && def.cellDataType && !def.dataType) {
                             def.dataType = def.cellDataType;
                         }
+                        // Apply step of 60 seconds when using datetime
+                        if (def?.cellEditor === 'agDateStringCellEditor') {
+                            def.cellEditorParams = {
+                                step: 60,
+                                ...(def.cellEditorParams || {})
+                            };
+                        }
+                        if (def?.filter === 'agDateColumnFilter') {
+                            def.filterParams = {
+                                step: 60,
+                                ...(def.filterParams || {})
+                            };
+                        }
                     });
                     parsedDefs = temp;
                 }
@@ -187,6 +200,8 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                 def.filter = 'agDateColumnFilter';
                 def.cellEditor = 'agDateStringCellEditor';
                 def.dataType = 'dateTimeString';
+                def.filterParams = { step: 60 };
+                def.cellEditorParams = { step: 60 };
             } else if (dt.includes('date')) {
                 def.filter = 'agDateColumnFilter';
                 def.cellEditor = 'agDateStringCellEditor';

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Set the `filter` key to one of AG Grid's built‑in filter names:
 * `true` – use the default filter for the data type
 
 Extra configuration can be supplied using `filterParams`.
+When editing or filtering date/time values you can remove the seconds by setting `step: 60`.
 
 To edit both date and time values, use `agDateStringCellEditor` and set
 `dataType: 'dateTimeString'` in your column definition. Enable the browser
@@ -77,7 +78,8 @@ date picker and ensure the time picker is shown by including `includeTime: true`
 cellEditorParams: {
   useBrowserDatePicker: true,
   inputType: 'datetime-local',
-  includeTime: true
+  includeTime: true,
+  step: 60
 }
 ```
 
@@ -88,7 +90,8 @@ To show a time picker in the filter, set the same `inputType` on the
 filterParams: {
   browserDatePicker: true,
   inputType: 'datetime-local',
-  includeTime: true
+  includeTime: true,
+  step: 60
 }
 ```
 


### PR DESCRIPTION
## Summary
- ensure seconds are omitted from date cell editors and filters
- document using `step: 60` to hide seconds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6881c627c5188333bbd4e0c90b7e47a0