### PR TITLE
Add Fluent UI date/time picker

### DIFF
--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -8,6 +8,8 @@
 
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { AgGridReact } from 'ag-grid-react';
+import FluentDateTimeCellEditor from './FluentDateTimeCellEditor';
+import FluentDateInput from './FluentDateInput';
 import type { CellEditingStoppedEvent } from 'ag-grid-community';
 import 'ag-grid-community/styles/ag-grid.css'; // Core CSS
 import 'ag-grid-community/styles/ag-theme-balham.css';
@@ -183,7 +185,11 @@ const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selec
         suppressAggFuncInHeader: true,
         enableRangeSelection: false,
         suppressRowClickSelection: multiSelect,
-        popupParent: typeof document !== 'undefined' ? document.body : undefined
+        popupParent: typeof document !== 'undefined' ? document.body : undefined,
+        components: {
+            fluentDateTimeCellEditor: FluentDateTimeCellEditor,
+            fluentDateInput: FluentDateInput
+        }
     }), [finalColumnDefs, multiSelect]);
 
     const gridRef = useRef<AgGridReact<any>>(null);

--- a/AgGrid/components/FluentDateInput.tsx
+++ b/AgGrid/components/FluentDateInput.tsx
@@ -1,0 +1,21 @@
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import type { IDateParams } from 'ag-grid-community';
+import FluentDateTimePicker from './FluentDateTimePicker';
+
+const FluentDateInput = forwardRef((props: IDateParams, ref) => {
+  const [val, setVal] = useState<string | null>(null);
+
+  useImperativeHandle(ref, () => ({
+    getDate: () => (val ? new Date(val) : null),
+    setDate: (d: Date | null) => { setVal(d ? d.toISOString().slice(0,16) : null); },
+    setInputPlaceholder: () => {},
+    setInputAriaLabel: () => {},
+    setDisabled: () => {},
+    afterGuiAttached: () => {},
+    refresh: () => {}
+  }));
+
+  return <FluentDateTimePicker value={val ?? undefined} onChange={setVal} />;
+});
+
+export default FluentDateInput;

--- a/AgGrid/components/FluentDateTimeCellEditor.tsx
+++ b/AgGrid/components/FluentDateTimeCellEditor.tsx
@@ -1,0 +1,16 @@
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import type { ICellEditorParams } from 'ag-grid-community';
+import FluentDateTimePicker from './FluentDateTimePicker';
+
+const FluentDateTimeCellEditor = forwardRef((props: ICellEditorParams, ref) => {
+  const [val, setVal] = useState<string>(props.value ?? '2025-05-04T21:35');
+
+  useImperativeHandle(ref, () => ({
+    getValue: () => val,
+    isPopup: () => true,
+  }));
+
+  return <FluentDateTimePicker value={val} onChange={(v) => v && setVal(v)} />;
+});
+
+export default FluentDateTimeCellEditor;

--- a/AgGrid/components/FluentDateTimePicker.tsx
+++ b/AgGrid/components/FluentDateTimePicker.tsx
@@ -1,0 +1,63 @@
+import React, { useState, useRef } from 'react';
+import { TextField, Callout, DatePicker, Dropdown, IDropdownOption, PrimaryButton, Stack } from '@fluentui/react';
+
+interface Props {
+  value?: string | null;
+  onChange?: (val: string | null) => void;
+}
+
+const hours: IDropdownOption[] = Array.from({ length: 12 }, (_, i) => ({ key: i + 1, text: String(i + 1) }));
+const minutes: IDropdownOption[] = Array.from({ length: 60 }, (_, i) => ({ key: i, text: i.toString().padStart(2, '0') }));
+const ampm: IDropdownOption[] = [ { key: 'AM', text: 'AM' }, { key: 'PM', text: 'PM' } ];
+
+export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
+  const initial = value ? new Date(value) : new Date('2025-05-04T21:35:00');
+  const [date, setDate] = useState<Date>(initial);
+  const [hour, setHour] = useState<number>((initial.getHours() % 12) || 12);
+  const [minute, setMinute] = useState<number>(initial.getMinutes());
+  const [ampmVal, setAmPmVal] = useState<string>(initial.getHours() >= 12 ? 'PM' : 'AM');
+  const [open, setOpen] = useState(false);
+  const target = useRef<HTMLDivElement | null>(null);
+
+  const formatted = () => {
+    const h = hour === 12 ? 0 : hour;
+    const fullHour = ampmVal === 'PM' ? h + 12 : h;
+    const d = new Date(date);
+    d.setHours(fullHour);
+    d.setMinutes(minute);
+    d.setSeconds(0);
+    return d.toLocaleString();
+  };
+
+  const apply = () => {
+    const h = hour === 12 ? 0 : hour;
+    const fullHour = ampmVal === 'PM' ? h + 12 : h;
+    const d = new Date(date);
+    d.setHours(fullHour);
+    d.setMinutes(minute);
+    d.setSeconds(0);
+    setOpen(false);
+    onChange?.(d.toISOString().slice(0,16));
+  };
+
+  return (
+    <div ref={target}>
+      <TextField readOnly value={formatted()} onClick={() => setOpen(true)} />
+      {open && target.current && (
+        <Callout target={target.current} onDismiss={() => setOpen(false)}>
+          <Stack tokens={{ childrenGap: 8, padding: 8 }}>
+            <DatePicker value={date} onSelectDate={(d) => d && setDate(d)} />
+            <Stack horizontal tokens={{ childrenGap: 8 }}>
+              <Dropdown options={hours} selectedKey={hour} onChange={(_, o) => setHour(Number(o?.key))} />
+              <Dropdown options={minutes} selectedKey={minute} onChange={(_, o) => setMinute(Number(o?.key))} />
+              <Dropdown options={ampm} selectedKey={ampmVal} onChange={(_, o) => setAmPmVal(String(o?.key))} />
+            </Stack>
+            <PrimaryButton text="OK" onClick={apply} />
+          </Stack>
+        </Callout>
+      )}
+    </div>
+  );
+};
+
+export default FluentDateTimePicker;

--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -191,23 +191,15 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                             def.dataType = def.cellDataType;
                         }
                         if (def?.cellEditor === 'agDateStringCellEditor') {
-                            def.cellEditorParams = {
-                                useBrowserDatePicker: true,
-                                inputType: 'datetime-local',
-                                includeTime: true,
-                                step: 60,
-                                ...(def.cellEditorParams || {})
-                            };
+                            def.cellEditor = 'fluentDateTimeCellEditor';
                             if (!def.valueFormatter) {
                                 def.valueFormatter = (p: any) => this.formatDisplay(p.value);
                             }
                         }
                         if (def?.filter === 'agDateColumnFilter') {
                             def.filterParams = {
-                                browserDatePicker: true,
-                                inputType: 'datetime-local',
-                                includeTime: true,
-                                step: 60,
+                                browserDatePicker: false,
+                                dateComponent: 'fluentDateInput',
                                 ...(def.filterParams || {})
                             };
                         }
@@ -227,24 +219,13 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
             const dt = (col.dataType || '').toLowerCase();
             if (dt.includes('dateandtime')) {
                 def.filter = 'agDateColumnFilter';
-                def.cellEditor = 'agDateStringCellEditor';
+                def.cellEditor = 'fluentDateTimeCellEditor';
                 def.dataType = 'dateTimeString';
-                def.filterParams = {
-                    browserDatePicker: true,
-                    inputType: 'datetime-local',
-                    includeTime: true,
-                    step: 60
-                };
-                def.cellEditorParams = {
-                    useBrowserDatePicker: true,
-                    inputType: 'datetime-local',
-                    includeTime: true,
-                    step: 60
-                };
+                def.filterParams = { browserDatePicker: false, dateComponent: 'fluentDateInput' };
                 def.valueFormatter = (p: any) => this.formatDisplay(p.value);
             } else if (dt.includes('date')) {
                 def.filter = 'agDateColumnFilter';
-                def.cellEditor = 'agDateStringCellEditor';
+                def.cellEditor = 'fluentDateTimeCellEditor';
                 def.dataType = 'dateString';
             }
             return def;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pcf-project",
       "version": "1.0.0",
       "dependencies": {
+        "@fluentui/react": "^8.123.1",
         "ag-grid-community": "^34.0.2",
         "ag-grid-react": "^34.0.2",
         "axios": "^1.6.7",
@@ -1963,6 +1964,219 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fluentui/date-time-utilities": {
+      "version": "8.6.10",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.6.10.tgz",
+      "integrity": "sha512-Bxq8DIMkFvkpCA1HKtCHdnFwPAnXLz3TkGp9kpi2T6VIv6VtLVSxRn95mbsUydpP9Up/DLglp/z9re5YFBGNbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/set-version": "^8.2.24",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fluentui/dom-utilities": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.3.10.tgz",
+      "integrity": "sha512-6WDImiLqTOpkEtfUKSStcTDpzmJfL6ZammomcjawN9xH/8u8G3Hx72CIt2MNck9giw/oUlNLJFdWRAjeP3rmPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/set-version": "^8.2.24",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fluentui/font-icons-mdl2": {
+      "version": "8.5.62",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.62.tgz",
+      "integrity": "sha512-8yIJ1RlOJIXNS+Ac3dKL8LucFlnAPK3jbzYWRNq7rg1pVSdbtCmFCz1eEAgLxVdAfjx1/9Bei/yQr5Fv7WwV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/set-version": "^8.2.24",
+        "@fluentui/style-utilities": "^8.12.2",
+        "@fluentui/utilities": "^8.15.22",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fluentui/foundation-legacy": {
+      "version": "8.4.29",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.4.29.tgz",
+      "integrity": "sha512-fSoYEdwk9VBEOPMtHMZ5xsCNCAH+lz104T6oHu9Fpf2VzdFE9ZqnjK3rQNV7xFZcjZtLaH2WUTEGUfpEYlcdDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/merge-styles": "^8.6.14",
+        "@fluentui/set-version": "^8.2.24",
+        "@fluentui/style-utilities": "^8.12.2",
+        "@fluentui/utilities": "^8.15.22",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/keyboard-key": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.23.tgz",
+      "integrity": "sha512-9GXeyUqNJUdg5JiQUZeGPiKnRzMRi9YEUn1l9zq6X/imYdMhxHrxpVZS12129cBfgvPyxt9ceJpywSfmLWqlKA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fluentui/merge-styles": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.6.14.tgz",
+      "integrity": "sha512-vghuHFAfQgS9WLIIs4kgDOCh/DHd5vGIddP4/bzposhlAVLZR6wUBqldm9AuCdY88r5LyCRMavVJLV+Up3xdvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/set-version": "^8.2.24",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fluentui/react": {
+      "version": "8.123.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.123.1.tgz",
+      "integrity": "sha512-wf9xfj6RQ8BGMfSSgZSwUrMCtLH3B78LUoP2rYVQ9zzL5ZzVvZF5CoHj+8Va/OfaOWDfeAxh38xpMzGh7NG0eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/date-time-utilities": "^8.6.10",
+        "@fluentui/font-icons-mdl2": "^8.5.62",
+        "@fluentui/foundation-legacy": "^8.4.29",
+        "@fluentui/merge-styles": "^8.6.14",
+        "@fluentui/react-focus": "^8.9.25",
+        "@fluentui/react-hooks": "^8.8.19",
+        "@fluentui/react-portal-compat-context": "^9.0.13",
+        "@fluentui/react-window-provider": "^2.2.30",
+        "@fluentui/set-version": "^8.2.24",
+        "@fluentui/style-utilities": "^8.12.2",
+        "@fluentui/theme": "^2.6.67",
+        "@fluentui/utilities": "^8.15.22",
+        "@microsoft/load-themed-styles": "^1.10.26",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-focus": {
+      "version": "8.9.25",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.9.25.tgz",
+      "integrity": "sha512-okDwer2ZHSBVEm6ISY2moruCuxa4Y0+AqP7DdoZpceoaAdHURZyLP3j7wxCEJEMRSoqKu5C6xNGn/Rxd5xPXLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-key": "^0.4.23",
+        "@fluentui/merge-styles": "^8.6.14",
+        "@fluentui/set-version": "^8.2.24",
+        "@fluentui/style-utilities": "^8.12.2",
+        "@fluentui/utilities": "^8.15.22",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-hooks": {
+      "version": "8.8.19",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.8.19.tgz",
+      "integrity": "sha512-uXcETVTl2L0G/Ocyb2Rjym96tcJd2NaZ2Hqt6EJcBb9KJD9irNeXjCCxsRNPC5kBDbfrQML2aai+M2kU9lZKNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-window-provider": "^2.2.30",
+        "@fluentui/set-version": "^8.2.24",
+        "@fluentui/utilities": "^8.15.22",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-portal-compat-context": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.13.tgz",
+      "integrity": "sha512-N+c6Qs775jnr/4WIzsQuNaRu4v16fa+gGsOCzzU1bqxX0IR9BSjjO2oLGC6luaAOqlQP+JIwn/aumOIJICKXkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-window-provider": {
+      "version": "2.2.30",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.30.tgz",
+      "integrity": "sha512-2SXuiZcU29W0D9zfExcTfzVx97OI50YCn5fGGO0bTDuP5VxzTQp1mipAY4qm/yJMMinoXkzBGLl1rK0Tdtxh1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/set-version": "^8.2.24",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/set-version": {
+      "version": "8.2.24",
+      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.24.tgz",
+      "integrity": "sha512-8uNi2ThvNgF+6d3q2luFVVdk/wZV0AbRfJ85kkvf2+oSRY+f6QVK0w13vMorNhA5puumKcZniZoAfUF02w7NSg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fluentui/style-utilities": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.12.2.tgz",
+      "integrity": "sha512-inDXaSs3Fj+oM5vIlqws9sQa+zh0Nk1+ZGFGCxsVw9jSGT2OD08Hx5oh4hio3wWqDUa78zZ6VEzGChTaLyOm4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/merge-styles": "^8.6.14",
+        "@fluentui/set-version": "^8.2.24",
+        "@fluentui/theme": "^2.6.67",
+        "@fluentui/utilities": "^8.15.22",
+        "@microsoft/load-themed-styles": "^1.10.26",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fluentui/theme": {
+      "version": "2.6.67",
+      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.67.tgz",
+      "integrity": "sha512-+9+VkIkZ+NCQDXFP6+WV2ChAj/KHphOEDCvGO15w8ql7sqRxeRQACtoWYNq1tAAsodbnq/amCfo2PNy2VIcIOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/merge-styles": "^8.6.14",
+        "@fluentui/set-version": "^8.2.24",
+        "@fluentui/utilities": "^8.15.22",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/utilities": {
+      "version": "8.15.22",
+      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.15.22.tgz",
+      "integrity": "sha512-ZhDO+6dVLjf2BbHizCA2bnVFLPmOSpemsTMtEY/Nr5fhot5+xeoZVBJrr10X6wN0fTdfMketj/+rnkh5hWXljg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/dom-utilities": "^2.3.10",
+        "@fluentui/merge-styles": "^8.6.14",
+        "@fluentui/react-window-provider": "^2.2.30",
+        "@fluentui/set-version": "^8.2.24",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -2059,6 +2273,12 @@
       "dependencies": {
         "requireindex": "~1.2.0"
       }
+    },
+    "node_modules/@microsoft/load-themed-styles": {
+      "version": "1.10.295",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.295.tgz",
+      "integrity": "sha512-W+IzEBw8a6LOOfRJM02dTT7BDZijxm+Z7lhtOAz1+y9vQm1Kdz9jlAO+qCEKsfxtUOmKilW8DIRqFw2aUgKeGg==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2187,6 +2407,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2266,14 +2495,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/react": {
       "version": "18.2.61",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.61.tgz",
       "integrity": "sha512-NURTN0qNnJa7O/k4XUkEW2yfygA+NxS0V5h1+kp9jPwhzZy95q3ADoGMP0+JypMhrZBTTgjKAUlTctde1zzeQA==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2284,7 +2511,6 @@
       "version": "18.2.19",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
       "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -2292,8 +2518,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -3828,8 +4053,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -8095,10 +8319,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "refreshTypes": "pcf-scripts refreshTypes"
   },
   "dependencies": {
+    "@fluentui/react": "^8.123.1",
     "ag-grid-community": "^34.0.2",
     "ag-grid-react": "^34.0.2",
     "axios": "^1.6.7",


### PR DESCRIPTION
## Summary
- add FluentDateTimePicker, FluentDateTimeCellEditor, and FluentDateInput components
- register the custom picker and replace usage of agDateStringCellEditor
- hook the picker into agDateColumnFilter
- install `@fluentui/react`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68829f46d41883338d3b06f8e1c22357