### PR TITLE
Update datetime filter and editor styling

### DIFF
--- a/AgGrid/components/FluentDateTimePicker.tsx
+++ b/AgGrid/components/FluentDateTimePicker.tsx
@@ -41,8 +41,17 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
   };
 
   return (
-    <div ref={target}>
-      <TextField readOnly value={formatted()} onClick={() => setOpen(true)} />
+    <div ref={target} className="fluent-date-time-editor">
+      <TextField
+        readOnly
+        value={formatted()}
+        onClick={() => setOpen(true)}
+        styles={{
+          root: { height: '100%' },
+          fieldGroup: { height: '100%' },
+          field: { padding: '0 4px', lineHeight: '24px' }
+        }}
+      />
       {open && target.current && (
         <Callout target={target.current} onDismiss={() => setOpen(false)}>
           <Stack tokens={{ childrenGap: 8, padding: 8 }}>

--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -227,6 +227,7 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                 def.filter = 'agDateColumnFilter';
                 def.cellEditor = 'fluentDateTimeCellEditor';
                 def.dataType = 'dateString';
+                def.filterParams = { browserDatePicker: false, dateComponent: 'fluentDateInput' };
             }
             return def;
         });

--- a/AgGrid/styles/custom.css
+++ b/AgGrid/styles/custom.css
@@ -141,7 +141,7 @@
 }
 
 [class^="ag-"], [class^="ag-"]:focus, [class^="ag-"]::after, [class^="ag-"]::before {
-	box-sizing: border-box;
+        box-sizing: border-box;
 }
 
 :where(.ag-theme-params-1) {
@@ -153,4 +153,20 @@
 [class*="ag-theme-"] {
     --ag-borders: solid 1px;
     --ag-border-radius: var(--ag-border-radius);
+}
+
+/* Compact date/time editor */
+.fluent-date-time-editor {
+    height: 100%;
+    display: flex;
+    align-items: center;
+}
+.fluent-date-time-editor .ms-TextField,
+.fluent-date-time-editor .ms-TextField-fieldGroup {
+    height: 100%;
+}
+.fluent-date-time-editor input {
+    height: 100%;
+    padding-top: 0;
+    padding-bottom: 0;
 }


### PR DESCRIPTION
## Summary
- use the custom datetime picker for date filters as well
- tighten FluentDateTimePicker so it fits inside a grid row
- tweak CSS for compact date/time editor

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6882abc8393c8333bacb0f40d0723bea