### PR TITLE
Improve date filter component

### DIFF
--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -186,9 +186,10 @@ const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selec
         enableRangeSelection: false,
         suppressRowClickSelection: multiSelect,
         popupParent: typeof document !== 'undefined' ? document.body : undefined,
-        components: {
+        frameworkComponents: {
             fluentDateTimeCellEditor: FluentDateTimeCellEditor,
-            fluentDateInput: FluentDateInput
+            fluentDateInput: FluentDateInput,
+            agDateInput: FluentDateInput
         }
     }), [finalColumnDefs, multiSelect]);
 

--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -201,7 +201,10 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                         }
                         if (def?.filter === 'agDateColumnFilter') {
                             def.filterParams = {
-                                browserDatePicker: false,
+                                browserDatePicker: true,
+                                inputType: 'datetime-local',
+                                includeTime: true,
+                                step: 60,
                                 dateComponent: 'fluentDateInput',
                                 ...(def.filterParams || {})
                             };
@@ -224,13 +227,25 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                 def.filter = 'agDateColumnFilter';
                 def.cellEditor = 'fluentDateTimeCellEditor';
                 def.dataType = 'dateTimeString';
-                def.filterParams = { browserDatePicker: false, dateComponent: 'fluentDateInput' };
+                def.filterParams = {
+                    browserDatePicker: true,
+                    inputType: 'datetime-local',
+                    includeTime: true,
+                    step: 60,
+                    dateComponent: 'fluentDateInput'
+                };
                 def.valueFormatter = (p: any) => this.formatDisplay(p.value);
             } else if (dt.includes('date')) {
                 def.filter = 'agDateColumnFilter';
                 def.cellEditor = 'fluentDateTimeCellEditor';
                 def.dataType = 'dateString';
-                def.filterParams = { browserDatePicker: false, dateComponent: 'fluentDateInput' };
+                def.filterParams = {
+                    browserDatePicker: true,
+                    inputType: 'datetime-local',
+                    includeTime: true,
+                    step: 60,
+                    dateComponent: 'fluentDateInput'
+                };
             }
             return def;
         });

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ filterParams: {
 }
 ```
 
+When column definitions are omitted, the component automatically applies this
+`agDateColumnFilter` setup for any detected date fields so the filter's picker
+matches the built-in `FluentDateTimeCellEditor`.
+
 ### Cell Content
 The grid provides several options for controlling how values are displayed inside each cell:
 


### PR DESCRIPTION
## Summary
- expose custom editor components via `frameworkComponents`
- ensure automatic date columns configure the date filter with matching params
- document that default date fields get the `FluentDateTime` filter

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6882e6e6a7ac8333a63c5a5d7cdf99f0