### PR TITLE
Fix date picker timezone

### DIFF
--- a/AgGrid/components/FluentDateInput.tsx
+++ b/AgGrid/components/FluentDateInput.tsx
@@ -1,13 +1,14 @@
 import React, { forwardRef, useImperativeHandle, useState } from 'react';
 import type { IDateParams } from 'ag-grid-community';
 import FluentDateTimePicker from './FluentDateTimePicker';
+import { toLocalIsoMinutes } from '../utils/date';
 
 const FluentDateInput = forwardRef((props: IDateParams, ref) => {
   const [val, setVal] = useState<string | null>(null);
 
   useImperativeHandle(ref, () => ({
     getDate: () => (val ? new Date(val) : null),
-    setDate: (d: Date | null) => { setVal(d ? d.toISOString().slice(0,16) : null); },
+    setDate: (d: Date | null) => { setVal(d ? toLocalIsoMinutes(d) : null); },
     setInputPlaceholder: () => {},
     setInputAriaLabel: () => {},
     setDisabled: () => {},

--- a/AgGrid/components/FluentDateTimePicker.tsx
+++ b/AgGrid/components/FluentDateTimePicker.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { TextField, Callout, DatePicker, Dropdown, IDropdownOption, PrimaryButton, Stack } from '@fluentui/react';
+import { toLocalIsoMinutes } from '../utils/date';
 
 interface Props {
   value?: string | null;
@@ -37,7 +38,7 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
     d.setMinutes(minute);
     d.setSeconds(0);
     setOpen(false);
-    onChange?.(d.toISOString().slice(0,16));
+    onChange?.(toLocalIsoMinutes(d));
   };
 
   return (

--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -3,6 +3,7 @@ import MyAgGrid from './components/AgGrid'
 import React from "react";
 import ReactDOM from "react-dom";
 import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
+import { toLocalIsoMinutes } from './utils/date';
 
 // Ensure all community grid modules are registered for compatibility with
 // the latest AG Grid versions.
@@ -72,7 +73,7 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
 
     private formatToMinutes(val: unknown): unknown {
         if (val instanceof Date) {
-            return val.toISOString().slice(0, 16);
+            return toLocalIsoMinutes(val);
         }
         if (typeof val === 'string') {
             const m = val.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2})/);
@@ -283,7 +284,7 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                     }
                 }
                 if (value instanceof Date) {
-                    value = value.toISOString();
+                    value = toLocalIsoMinutes(value);
                 }
                 if (dt.includes('dateandtime')) {
                     value = this.formatToMinutes(value);

--- a/AgGrid/utils/date.ts
+++ b/AgGrid/utils/date.ts
@@ -1,0 +1,5 @@
+export function toLocalIsoMinutes(d: Date): string {
+  const offsetMs = d.getTimezoneOffset() * 60000;
+  const local = new Date(d.getTime() - offsetMs);
+  return local.toISOString().slice(0, 16);
+}


### PR DESCRIPTION
## Summary
- normalize date values with a utility that preserves local timezone
- use this helper when parsing dataset values and during date edits

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6882f10083908333bec2c11b674f99d4