### PR TITLE
Fix date display formatting and reopen pickers

### DIFF
--- a/AgGrid/components/FluentDateTimePicker.tsx
+++ b/AgGrid/components/FluentDateTimePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { TextField, Callout, DatePicker, Dropdown, IDropdownOption, PrimaryButton, Stack } from '@fluentui/react';
 import { toLocalIsoMinutes } from '../utils/date';
 
@@ -20,6 +20,16 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
   const [open, setOpen] = useState(false);
   const target = useRef<HTMLDivElement | null>(null);
 
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
+  useEffect(() => {
+    if (!open && target.current) {
+      target.current.focus();
+    }
+  }, [open]);
+
   const formatted = () => {
     const h = hour === 12 ? 0 : hour;
     const fullHour = ampmVal === 'PM' ? h + 12 : h;
@@ -27,7 +37,14 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
     d.setHours(fullHour);
     d.setMinutes(minute);
     d.setSeconds(0);
-    return d.toLocaleString();
+    return d.toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
   };
 
   const apply = () => {

--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -98,12 +98,13 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
         if (parsed instanceof Date && !isNaN(parsed.getTime())) {
             const dateStr = parsed.toLocaleDateString(undefined, {
                 year: 'numeric',
-                month: '2-digit',
-                day: '2-digit'
+                month: 'numeric',
+                day: 'numeric'
             });
             const timeStr = parsed.toLocaleTimeString(undefined, {
                 hour: 'numeric',
-                minute: '2-digit'
+                minute: '2-digit',
+                hour12: true
             });
             return `${dateStr} ${timeStr}`;
         }


### PR DESCRIPTION
## Summary
- show date with numeric month/day and 12‑hour time
- auto-open date picker when filter or editor is shown
- keep focus on input when picker closes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688309cf65cc8333a7ce73c86fcf3616