### PR TITLE
Fix date/time pickers visibility

### DIFF
--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -8,6 +8,7 @@
 
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { AgGridReact } from 'ag-grid-react';
+import { LayerHost } from '@fluentui/react';
 import FluentDateTimeCellEditor from './FluentDateTimeCellEditor';
 import FluentDateInput from './FluentDateInput';
 import type { CellEditingStoppedEvent } from 'ag-grid-community';
@@ -338,6 +339,7 @@ const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selec
                 onCellValueChanged={onCellValueChangedHandler}
                 onCellEditingStopped={onCellEditingStoppedHandler}
             />
+            <LayerHost id="fluent-layer-host" />
         </div>
     );
 });

--- a/AgGrid/components/FluentDateTimePicker.tsx
+++ b/AgGrid/components/FluentDateTimePicker.tsx
@@ -71,7 +71,11 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
         }}
       />
       {open && target.current && (
-        <Callout target={target.current} onDismiss={() => setOpen(false)}>
+        <Callout
+          target={target.current}
+          onDismiss={() => setOpen(false)}
+          layerProps={{ hostId: 'fluent-layer-host' }}
+        >
           <Stack tokens={{ childrenGap: 8, padding: 8 }}>
             <DatePicker value={date} onSelectDate={(d) => d && setDate(d)} />
             <Stack horizontal tokens={{ childrenGap: 8 }}>


### PR DESCRIPTION
## Summary
- host Fluent UI callouts within the grid container
- use LayerHost and target hostId so pickers render properly inside PCF

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6883171b7c948333a4dc0ad0e83fa1e3