### PR TITLE
Fix date pickers missing

### DIFF
--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -223,11 +223,10 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                         if (def?.filter === 'agDateColumnFilter') {
                             def.cellEditorPopup = true;
                             def.filterParams = {
-                                browserDatePicker: false,
+                                browserDatePicker: true,
                                 inputType: 'datetime-local',
                                 includeTime: true,
                                 step: 60,
-                                dateComponent: 'fluentDateInput',
                                 ...(def.filterParams || {})
                             };
                         }
@@ -251,11 +250,10 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                 def.cellEditorPopup = true;
                 def.dataType = 'dateTimeString';
                 def.filterParams = {
-                    browserDatePicker: false,
+                    browserDatePicker: true,
                     inputType: 'datetime-local',
                     includeTime: true,
-                    step: 60,
-                    dateComponent: 'fluentDateInput'
+                    step: 60
                 };
                 def.valueFormatter = (p: any) => this.formatDisplay(p.value);
             } else if (dt.includes('date')) {
@@ -264,11 +262,10 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                 def.cellEditorPopup = true;
                 def.dataType = 'dateString';
                 def.filterParams = {
-                    browserDatePicker: false,
+                    browserDatePicker: true,
                     inputType: 'datetime-local',
                     includeTime: true,
-                    step: 60,
-                    dateComponent: 'fluentDateInput'
+                    step: 60
                 };
             }
             return def;


### PR DESCRIPTION
## Summary
- switch AG Grid column definitions back to `browserDatePicker: true`
- drop custom dateComponent so default pickers render

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6883acde0ce08333bb41f69287a750a0