### PR TITLE
Fix custom date picker callout

### DIFF
--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -8,7 +8,6 @@
 
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { AgGridReact } from 'ag-grid-react';
-import { LayerHost } from '@fluentui/react';
 import FluentDateTimeCellEditor from './FluentDateTimeCellEditor';
 import FluentDateInput from './FluentDateInput';
 import type { CellEditingStoppedEvent } from 'ag-grid-community';
@@ -339,7 +338,6 @@ const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selec
                 onCellValueChanged={onCellValueChangedHandler}
                 onCellEditingStopped={onCellEditingStoppedHandler}
             />
-            <LayerHost id="fluent-layer-host" />
         </div>
     );
 });

--- a/AgGrid/components/FluentDateTimePicker.tsx
+++ b/AgGrid/components/FluentDateTimePicker.tsx
@@ -74,7 +74,6 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
         <Callout
           target={target.current}
           onDismiss={() => setOpen(false)}
-          layerProps={{ hostId: 'fluent-layer-host' }}
         >
           <Stack tokens={{ childrenGap: 8, padding: 8 }}>
             <DatePicker value={date} onSelectDate={(d) => d && setDate(d)} />


### PR DESCRIPTION
## Summary
- remove unused LayerHost from grid
- simplify Callout props for custom date picker

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688465e9993883338754853a944b4c09