### PR TITLE
Restore custom date picker features

### DIFF
--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -186,9 +186,10 @@ const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selec
         enableRangeSelection: false,
         suppressRowClickSelection: multiSelect,
         popupParent: typeof document !== 'undefined' ? document.body : undefined,
-        components: {
+        frameworkComponents: {
             fluentDateTimeCellEditor: FluentDateTimeCellEditor,
-            fluentDateInput: FluentDateInput
+            fluentDateInput: FluentDateInput,
+            agDateInput: FluentDateInput
         }
     }), [finalColumnDefs, multiSelect]);
 

--- a/AgGrid/components/FluentDateInput.tsx
+++ b/AgGrid/components/FluentDateInput.tsx
@@ -1,13 +1,14 @@
 import React, { forwardRef, useImperativeHandle, useState } from 'react';
 import type { IDateParams } from 'ag-grid-community';
 import FluentDateTimePicker from './FluentDateTimePicker';
+import { toLocalIsoMinutes } from '../utils/date';
 
 const FluentDateInput = forwardRef((props: IDateParams, ref) => {
   const [val, setVal] = useState<string | null>(null);
 
   useImperativeHandle(ref, () => ({
     getDate: () => (val ? new Date(val) : null),
-    setDate: (d: Date | null) => { setVal(d ? d.toISOString().slice(0,16) : null); },
+    setDate: (d: Date | null) => { setVal(d ? toLocalIsoMinutes(d) : null); },
     setInputPlaceholder: () => {},
     setInputAriaLabel: () => {},
     setDisabled: () => {},

--- a/AgGrid/components/FluentDateTimePicker.tsx
+++ b/AgGrid/components/FluentDateTimePicker.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { TextField, Callout, DatePicker, Dropdown, IDropdownOption, PrimaryButton, Stack } from '@fluentui/react';
+import { toLocalIsoMinutes } from '../utils/date';
 
 interface Props {
   value?: string | null;
@@ -19,6 +20,16 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
   const [open, setOpen] = useState(false);
   const target = useRef<HTMLDivElement | null>(null);
 
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
+  useEffect(() => {
+    if (!open && target.current) {
+      target.current.focus();
+    }
+  }, [open]);
+
   const formatted = () => {
     const h = hour === 12 ? 0 : hour;
     const fullHour = ampmVal === 'PM' ? h + 12 : h;
@@ -26,7 +37,14 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
     d.setHours(fullHour);
     d.setMinutes(minute);
     d.setSeconds(0);
-    return d.toLocaleString();
+    return d.toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
   };
 
   const apply = () => {
@@ -37,7 +55,7 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
     d.setMinutes(minute);
     d.setSeconds(0);
     setOpen(false);
-    onChange?.(d.toISOString().slice(0,16));
+    onChange?.(toLocalIsoMinutes(d));
   };
 
   return (
@@ -53,7 +71,11 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
         }}
       />
       {open && target.current && (
-        <Callout target={target.current} onDismiss={() => setOpen(false)}>
+        <Callout
+          target={target.current}
+          onDismiss={() => setOpen(false)}
+          doNotLayer
+        >
           <Stack tokens={{ childrenGap: 8, padding: 8 }}>
             <DatePicker value={date} onSelectDate={(d) => d && setDate(d)} />
             <Stack horizontal tokens={{ childrenGap: 8 }}>

--- a/AgGrid/styles/custom.css
+++ b/AgGrid/styles/custom.css
@@ -170,3 +170,23 @@
     padding-top: 0;
     padding-bottom: 0;
 }
+.field-756 {
+    font-family: var(--ag-cell-font-family);
+    font-size: var(--ag-font-size);
+    line-height: revert;
+    width: 100%;
+}
+.fluent-date-time-editor .ms-TextField, .fluent-date-time-editor .ms-TextField-fieldGroup {
+    height: auto;
+    background-color: transparent;
+    border: none;
+    margin-left: 4px;
+}
+.root-760 {
+       font-family: var(--ag-cell-font-family);
+       font-size: var(--ag-font-size);
+    width: 100%;
+}
+.fluent-date-time-editor input {
+       margin-left: 8px;
+}

--- a/AgGrid/utils/date.ts
+++ b/AgGrid/utils/date.ts
@@ -1,0 +1,5 @@
+export function toLocalIsoMinutes(d: Date): string {
+  const offsetMs = d.getTimezoneOffset() * 60000;
+  const local = new Date(d.getTime() - offsetMs);
+  return local.toISOString().slice(0, 16);
+}

--- a/README.md
+++ b/README.md
@@ -89,12 +89,17 @@ To show a time picker in the filter, set the same `inputType` on the
 
 ```PowerApps
 filterParams: {
-  browserDatePicker: true,
+  browserDatePicker: false,
+  dateComponent: 'fluentDateInput',
   inputType: 'datetime-local',
   includeTime: true,
   step: 60
 }
 ```
+
+When column definitions are omitted, the component automatically applies this
+`agDateColumnFilter` setup for any detected date fields so the filter's picker
+matches the built-in `FluentDateTimeCellEditor`.
 
 ### Cell Content
 The grid provides several options for controlling how values are displayed inside each cell:


### PR DESCRIPTION
## Summary
- wire up agDateInput framework component
- restore local time formatting helpers
- enhance date/time picker with focus, formatting and callout options
- provide custom date filter setup and CSS tweaks
- document new date filter defaults

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6887a3a1ce1c83339c66c5eec11f8b36