### PR TITLE
Ensure custom date picker triggers filter updates

### DIFF
--- a/AgGrid/components/FluentDateInput.tsx
+++ b/AgGrid/components/FluentDateInput.tsx
@@ -16,7 +16,12 @@ const FluentDateInput = forwardRef((props: IDateParams, ref) => {
     refresh: () => {}
   }));
 
-  return <FluentDateTimePicker value={val ?? undefined} onChange={setVal} />;
+  const handleChange = (v: string | null) => {
+    setVal(v);
+    props.onDateChanged();
+  };
+
+  return <FluentDateTimePicker value={val ?? undefined} onChange={handleChange} />;
 });
 
 export default FluentDateInput;


### PR DESCRIPTION
## Summary
- wire up the `onDateChanged` callback in `FluentDateInput`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68883d6c49108333ba54ca12fe0aee1c