### PR TITLE
Update Fluent date picker to open on click

### DIFF
--- a/AgGrid/components/FluentDateTimePicker.tsx
+++ b/AgGrid/components/FluentDateTimePicker.tsx
@@ -21,10 +21,6 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange }) => {
   const target = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    setOpen(true);
-  }, []);
-
-  useEffect(() => {
     if (!open && target.current) {
       target.current.focus();
     }

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ When column definitions are omitted, the component automatically applies this
 `agDateColumnFilter` setup for any detected date fields so the filter's picker
 matches the built-in `FluentDateTimeCellEditor`.
 
+The editor uses a custom Fluent UI picker that starts out displaying
+`5/4/2025 9:35 PM`. Click the field to open a popup where you can quickly choose
+the month, year, day and time (hour, minute and AM/PM).
+
 ### Cell Content
 The grid provides several options for controlling how values are displayed inside each cell:
 


### PR DESCRIPTION
## Summary
- disable auto-open for `FluentDateTimePicker`
- document custom Fluent UI picker behavior in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688842cc308483338ed37908d90f4466