### PR TITLE
Fix date picker defaults with agDateStringCellEditor

### DIFF
--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -244,6 +244,19 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                             }
                         } else if (def?.cellEditor === 'agDateStringCellEditor') {
                             def.cellEditor = 'fluentDateTimeCellEditor';
+                            def.cellEditorPopup = true;
+                            if (!def.filterParams) {
+                                def.filterParams = {};
+                            }
+                            def.filter = 'agDateColumnFilter';
+                            def.filterParams = {
+                                browserDatePicker: false,
+                                dateComponent: 'fluentDateInput',
+                                inputType: 'datetime-local',
+                                includeTime: true,
+                                step: 60,
+                                ...def.filterParams
+                            };
                             if (!def.valueFormatter) {
                                 def.valueFormatter = (p: any) => this.formatDisplay(p.value);
                             }


### PR DESCRIPTION
## Summary
- ensure custom date picker also activates when column defs use `agDateStringCellEditor`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68884f4853388333a14627a097c44223