### PR TITLE
Fix time display in picker

### DIFF
--- a/AgGrid/components/FluentDateTimePicker.tsx
+++ b/AgGrid/components/FluentDateTimePicker.tsx
@@ -44,16 +44,16 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange, autoOpe
     const fullHour = ampmVal === 'PM' ? h + 12 : h;
     const d = new Date(date);
     d.setHours(fullHour);
-    d.setMinutes(minute);
-    d.setSeconds(0);
-    return d.toLocaleString(undefined, {
-      year: 'numeric',
-      month: 'numeric',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true,
-    });
+    d.setMinutes(minute, 0, 0);
+    return (
+      d.toLocaleDateString() +
+      ' ' +
+      d.toLocaleTimeString([], {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      })
+    );
   };
 
   const apply = () => {


### PR DESCRIPTION
## Summary
- stop showing seconds in the custom `FluentDateTimePicker`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68891da28398833390ce4699a3af34b1