### PR TITLE
Hide seconds in native datetime picker

### DIFF
--- a/AgGrid/styles/custom.css
+++ b/AgGrid/styles/custom.css
@@ -190,3 +190,10 @@
 .fluent-date-time-editor input {
        margin-left: 8px;
 }
+
+/* Hide seconds from native datetime pickers */
+input[type="datetime-local"]::-webkit-datetime-edit-second-field,
+input[type="datetime-local"]::-webkit-datetime-edit-millisecond-field,
+input[type="datetime-local"]::-webkit-datetime-edit-separator:nth-of-type(3) {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- tweak custom CSS to hide seconds in native datetime-local pickers

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688922e8b74c8333b1eb93193f783214