### PR TITLE
Fix EditedRows datetime output

### DIFF
--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -121,13 +121,15 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
         return String(val);
     }
 
-    // Convert cell values to display strings for output when dealing with date
-    // types. Non-date values are returned unchanged.
+    // Convert cell values for output when dealing with date types. Returns a
+    // local ISO string (YYYY-MM-DDTHH:mm:ss) so the consumer can update the
+    // underlying record directly. Non-date values are returned unchanged.
     private convertForOutput(field: string, value: unknown): unknown {
         const def = this._columnDefs.find(c => c.field === field);
         const dt = def?.cellDataType || '';
         if (this.isDateType(dt) || this.isDateTimeType(dt)) {
-            return this.formatDisplay(value);
+            const normalized = this.formatToMinutes(value);
+            return typeof normalized === 'string' ? normalized : value;
         }
         return value;
     }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ When editing or filtering date/time values you can remove the seconds by setting
 Be sure to also set `inputType: 'datetime-local'` and `includeTime: true` so the time picker remains visible.
 Seconds are ignored by the custom picker, so no field for them is displayed.
 
+Any changed date or date/time values in **EditedRows** use a local ISO format (`YYYY-MM-DDTHH:mm:ss`). This lets you write updates back to Dataverse without additional conversion.
+
 To edit both date and time values, use `agDateStringCellEditor` and set
 `cellDataType: 'dateTimeString'` in your column definition. Enable the browser
 date picker and ensure the time picker is shown by including `includeTime: true`:

--- a/out/controls/AgGrid/styles/custom.css
+++ b/out/controls/AgGrid/styles/custom.css
@@ -66,7 +66,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    width: 100%;
+    width: 0px;
 }
 
 /* Ensure grid body background uses theme variable */
@@ -189,4 +189,11 @@
 }
 .fluent-date-time-editor input {
        margin-left: 8px;
+}
+
+/* Hide seconds from native datetime pickers */
+input[type="datetime-local"]::-webkit-datetime-edit-second-field,
+input[type="datetime-local"]::-webkit-datetime-edit-millisecond-field,
+input[type="datetime-local"]::-webkit-datetime-edit-separator:nth-of-type(3) {
+    display: none;
 }


### PR DESCRIPTION
## Summary
- output ISO strings for edited date/datetime fields
- document ISO output in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68893de5de4883338af054721e801880