### PR TITLE
Fix EditedRows output for single-row edits

### DIFF
--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -451,7 +451,11 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
             newValue: this.convertForOutput(cell.field, cell.newValue)
         }));
 
-        this._editedRows = Array.from(this._rowPatchesMap.values());
+        this._editedRows = Array.from(this._rowPatchesMap.values()).map(patch => ({
+            rowId: patch.rowId,
+            rowKey: patch.rowKey,
+            changes: { ...patch.changes }
+        }));
         this._editedRowRecords = this._editedRows.map(patch => {
             const record: any = {
                 rowKey: patch.rowKey !== undefined


### PR DESCRIPTION
## Summary
- ensure row patch objects are cloned when computing `EditedRows`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6889484b9a7483338f99cc4772fe480d