### PR TITLE
Fix date string edits losing seconds

### DIFF
--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -60,6 +60,9 @@ const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selec
     // compatibility.
     const stripSeconds = (val: unknown): unknown => {
         if (typeof val === 'string') {
+            if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(val)) {
+                return `${val}:00`;
+            }
             const m = val.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})/);
             if (m) {
                 return m[1];

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Be sure to also set `inputType: 'datetime-local'` and `includeTime: true` so the
 Seconds are ignored by the custom picker, so no field for them is displayed.
 
 Any changed date or date/time values in **EditedRows** use a local ISO format (`YYYY-MM-DDTHH:mm:ss`). This lets you write updates back to Dataverse without additional conversion.
+Strings missing the seconds component are padded with `:00` so all edits share the same format.
 
 To edit both date and time values, use `agDateStringCellEditor` and set
 `cellDataType: 'dateTimeString'` in your column definition. Enable the browser


### PR DESCRIPTION
## Summary
- normalize date strings when stripping seconds
- document the normalized datetime output

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68894f33adac83339d3be5ce997aa5ff