### PR TITLE
Fix row hover and selection highlighting

### DIFF
--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -290,7 +290,6 @@ const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selec
             '--ag-header-background-color': 'transparent',
             '--ag-control-panel-background-color': 'transparent',
             '--ag-background-color': 'transparent',
-            '--ag-row-hover-color': 'transparent',
             '--ag-odd-row-background-color': 'transparent',
             '--ag-border-color': 'transparent',
             '--ag-borders': 'none',

--- a/AgGrid/styles/custom.css
+++ b/AgGrid/styles/custom.css
@@ -138,7 +138,7 @@
 
 [class*="ag-theme-"] {
     --ag-background-color: none !important;
-    --ag-selected-row-background-color: none !important;
+    --ag-selected-row-background-color: #d0e9ff !important;
 }
 
 [class^="ag-"], [class^="ag-"]:focus, [class^="ag-"]::after, [class^="ag-"]::before {

--- a/out/controls/AgGrid/styles/custom.css
+++ b/out/controls/AgGrid/styles/custom.css
@@ -138,7 +138,7 @@
 
 [class*="ag-theme-"] {
     --ag-background-color: none !important;
-    --ag-selected-row-background-color: none !important;
+    --ag-selected-row-background-color: #d0e9ff !important;
 }
 
 [class^="ag-"], [class^="ag-"]:focus, [class^="ag-"]::after, [class^="ag-"]::before {


### PR DESCRIPTION
## Summary
- restore AG Grid hover highlight
- show a light blue color for selected rows

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688956bbc7e483338fd9ea38673cd8ac