### PR TITLE
Fix picker not opening on Firefox

### DIFF
--- a/AgGrid/components/FluentDateTimePicker.tsx
+++ b/AgGrid/components/FluentDateTimePicker.tsx
@@ -73,6 +73,13 @@ export const FluentDateTimePicker: React.FC<Props> = ({ value, onChange, autoOpe
         readOnly
         value={formatted()}
         onClick={() => setOpen(true)}
+        onFocus={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setOpen(true);
+          }
+        }}
         styles={{
           root: { height: '100%' },
           fieldGroup: { height: '100%' },


### PR DESCRIPTION
## Summary
- ensure FluentDateTimePicker opens when its text field gets focus

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6889874ce48c833399043455d4718dd7