### PR TITLE
Add AG Grid Theme Builder support

### DIFF
--- a/AgGrid/ControlManifest.Input.xml
+++ b/AgGrid/ControlManifest.Input.xml
@@ -32,6 +32,7 @@
     <property name="PaginationColor" display-name-key="PaginationColor" of-type="SingleLine.Text" usage="input" default-value="" />
       <property name="GridBackgroundColor" display-name-key="GridBackgroundColor" of-type="SingleLine.Text" usage="input" default-value="" />
       <property name="FontSize" display-name-key="FontSize" of-type="Decimal" usage="input" default-value="13" />
+      <property name="ThemeClass" display-name-key="ThemeClass" of-type="SingleLine.Text" usage="input" default-value="ag-theme-balham" />
       <property name="EnableBlur" display-name-key="EnableBlur" of-type="TwoOptions" usage="input" default-value="false" />
     <property name="MultiSelect" display-name-key="MultiSelect" of-type="TwoOptions" usage="input" default-value="true" />
     <property name="RowKey" display-name-key="RowKey" of-type="SingleLine.Text" usage="input" default-value="" />
@@ -56,6 +57,7 @@
     <resources>
       <code path="index.ts" order="1"/>
       <css path="styles/custom.css" order="1" />
+      <css path="styles/theme-builder.css" order="2" />
       <!-- <code path="css/grid.css" order="1"/> -->
       <!-- UNCOMMENT TO ADD MORE RESOURCES
       <css path="css/AgGrid.css" order="1" />

--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -31,6 +31,7 @@ interface MyAgGridProps {
     paginationColor?: string;
     gridBackgroundColor?: string;
     fontSize?: number | string;
+    themeClass?: string;
     enableBlur?: boolean;
     multiSelect?: boolean;
     readOnly?: boolean;
@@ -38,9 +39,9 @@ interface MyAgGridProps {
     resetVersion?: number;
 }
     
-const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selectedRowIds, onSelectionChanged, onCellValueChanged, headerColor, paginationColor, gridBackgroundColor, fontSize, enableBlur = false, multiSelect = true, readOnly = false, showPagination = true, resetVersion }) => {
+const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selectedRowIds, onSelectionChanged, onCellValueChanged, headerColor, paginationColor, gridBackgroundColor, fontSize, themeClass = 'ag-theme-balham', enableBlur = false, multiSelect = true, readOnly = false, showPagination = true, resetVersion }) => {
     console.log('AG Grid')
-    const divClass = 'ag-theme-balham';
+    const divClass = themeClass;
     const [autoDefName, setAutoDefName] = useState('');
     // Always use 'multiple' selection to keep checkbox column visible
     // When multiSelect is false we will enforce single selection manually

--- a/AgGrid/generated/ManifestTypes.d.ts
+++ b/AgGrid/generated/ManifestTypes.d.ts
@@ -10,6 +10,7 @@ export interface IInputs {
     PaginationColor: ComponentFramework.PropertyTypes.StringProperty;
     GridBackgroundColor: ComponentFramework.PropertyTypes.StringProperty;
     FontSize: ComponentFramework.PropertyTypes.DecimalNumberProperty;
+    ThemeClass: ComponentFramework.PropertyTypes.StringProperty;
     EnableBlur: ComponentFramework.PropertyTypes.TwoOptionsProperty;
     MultiSelect: ComponentFramework.PropertyTypes.TwoOptionsProperty;
     RowKey: ComponentFramework.PropertyTypes.StringProperty;

--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -71,6 +71,7 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
     private _lastResetSelectionFlag: boolean = false;
     private _resetVersion: number = 0;
     private _fontSize?: number;
+    private _themeClass: string = 'ag-theme-balham';
 
     private formatToMinutes(val: unknown): unknown {
         if (val instanceof Date) {
@@ -206,6 +207,7 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
         this._rowKeyField = context.parameters.RowKey.raw || undefined;
         this._readOnly = context.parameters.ReadOnly.raw === true;
         this._fontSize = context.parameters.FontSize.raw !== null ? context.parameters.FontSize.raw : undefined;
+        this._themeClass = context.parameters.ThemeClass.raw || 'ag-theme-balham';
         this._showEdited = context.parameters.ShowEdited.raw === true;
         let selectedKeys: string[] | undefined;
         const selectedKeysInput = context.parameters.SelectedRowKeys.raw;
@@ -381,6 +383,7 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                 paginationColor: context.parameters.PaginationColor.raw || undefined,
                 gridBackgroundColor: context.parameters.GridBackgroundColor.raw || undefined,
                 fontSize: this._fontSize,
+                themeClass: this._themeClass,
                 enableBlur: context.parameters.EnableBlur.raw === true,
                 multiSelect: this._multiSelect,
                 readOnly: this._readOnly,

--- a/AgGrid/styles/theme-builder.css
+++ b/AgGrid/styles/theme-builder.css
@@ -1,0 +1,11 @@
+@import "~ag-grid-community/styles/ag-grid.css";
+@import "~ag-grid-community/styles/ag-theme-balham.css";
+
+.ag-theme-builder {
+  --ag-balham-active-color: #008272;
+  --ag-header-background-color: #f3f2f1;
+  --ag-control-panel-background-color: #f3f2f1;
+  --ag-odd-row-background-color: #fafafa;
+  --ag-background-color: #ffffff;
+  --ag-grid-size: 6px;
+}

--- a/README.md
+++ b/README.md
@@ -194,3 +194,9 @@ The `custom.css` file imports AG Grid's core and Balham theme styles so the them
 ```
 
 This theme uses CSS variables for its colors, fonts and spacing. If your grid does not match the examples shown in the [AG Grid Themes guide](https://www.ag-grid.com/javascript-data-grid/themes/), verify that this stylesheet is included in the build output. You can override Balham's variables using the input properties `HeaderColor`, `PaginationColor` and `GridBackgroundColor` or by adding your own CSS rules.
+
+### Custom themes with the AG Grid Theme Builder
+
+The control also supports themes generated with the [AG Grid Theme Builder](https://www.ag-grid.com/theme-builder/).  
+Add the exported CSS file to the `styles` folder (for example `theme-builder.css`) and reference it in the manifest.  
+Use the new `ThemeClass` input property to specify the class name of your custom theme, such as `ag-theme-builder`.


### PR DESCRIPTION
## Summary
- expose `ThemeClass` input for custom themes
- add a sample theme from the AG Grid Theme Builder
- document using the Theme Builder

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688a8af7a88c83339a8c57fdb5f6deeb