### PR TITLE
Add dynamic theme support

### DIFF
--- a/AgGrid/ControlManifest.Input.xml
+++ b/AgGrid/ControlManifest.Input.xml
@@ -32,7 +32,8 @@
     <property name="PaginationColor" display-name-key="PaginationColor" of-type="SingleLine.Text" usage="input" default-value="" />
       <property name="GridBackgroundColor" display-name-key="GridBackgroundColor" of-type="SingleLine.Text" usage="input" default-value="" />
       <property name="FontSize" display-name-key="FontSize" of-type="Decimal" usage="input" default-value="13" />
-      <property name="ThemeClass" display-name-key="ThemeClass" of-type="SingleLine.Text" usage="input" default-value="ag-theme-balham" />
+      <property name="ThemeClass" display-name-key="ThemeClass" of-type="SingleLine.Text" usage="input" default-value="balham" />
+      <property name="CustomThemeCss" display-name-key="CustomThemeCss" of-type="SingleLine.TextArea" usage="input" default-value="" />
       <property name="EnableBlur" display-name-key="EnableBlur" of-type="TwoOptions" usage="input" default-value="false" />
     <property name="MultiSelect" display-name-key="MultiSelect" of-type="TwoOptions" usage="input" default-value="true" />
     <property name="RowKey" display-name-key="RowKey" of-type="SingleLine.Text" usage="input" default-value="" />

--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -12,7 +12,6 @@ import FluentDateTimeCellEditor from './FluentDateTimeCellEditor';
 import FluentDateInput from './FluentDateInput';
 import type { CellEditingStoppedEvent } from 'ag-grid-community';
 import 'ag-grid-community/styles/ag-grid.css'; // Core CSS
-import 'ag-grid-community/styles/ag-theme-balham.css';
 
 interface EditedCell {
     rowId: string;
@@ -32,6 +31,7 @@ interface MyAgGridProps {
     gridBackgroundColor?: string;
     fontSize?: number | string;
     themeClass?: string;
+    customThemeCss?: string;
     enableBlur?: boolean;
     multiSelect?: boolean;
     readOnly?: boolean;
@@ -39,7 +39,7 @@ interface MyAgGridProps {
     resetVersion?: number;
 }
     
-const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selectedRowIds, onSelectionChanged, onCellValueChanged, headerColor, paginationColor, gridBackgroundColor, fontSize, themeClass = 'ag-theme-balham', enableBlur = false, multiSelect = true, readOnly = false, showPagination = true, resetVersion }) => {
+const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selectedRowIds, onSelectionChanged, onCellValueChanged, headerColor, paginationColor, gridBackgroundColor, fontSize, themeClass = 'ag-theme-balham', customThemeCss, enableBlur = false, multiSelect = true, readOnly = false, showPagination = true, resetVersion }) => {
     console.log('AG Grid')
     const divClass = themeClass;
     const [autoDefName, setAutoDefName] = useState('');
@@ -48,6 +48,26 @@ const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selec
     const rowSelectionMode = 'multiple';
     const editedCellsRef = useRef<Set<string>>(new Set());
     const originalDataRef = useRef<Record<string, any>>({});
+    const styleRef = useRef<HTMLStyleElement>();
+
+    useEffect(() => {
+        if (customThemeCss) {
+            if (!styleRef.current) {
+                styleRef.current = document.createElement('style');
+                document.head.appendChild(styleRef.current);
+            }
+            styleRef.current.textContent = customThemeCss;
+        } else if (styleRef.current) {
+            styleRef.current.remove();
+            styleRef.current = undefined;
+        }
+        return () => {
+            if (styleRef.current) {
+                styleRef.current.remove();
+                styleRef.current = undefined;
+            }
+        };
+    }, [customThemeCss]);
 
     const valuesAreEqual = (a: unknown, b: unknown): boolean => {
         if (a === b) return true;

--- a/AgGrid/generated/ManifestTypes.d.ts
+++ b/AgGrid/generated/ManifestTypes.d.ts
@@ -11,6 +11,7 @@ export interface IInputs {
     GridBackgroundColor: ComponentFramework.PropertyTypes.StringProperty;
     FontSize: ComponentFramework.PropertyTypes.DecimalNumberProperty;
     ThemeClass: ComponentFramework.PropertyTypes.StringProperty;
+    CustomThemeCss: ComponentFramework.PropertyTypes.StringProperty;
     EnableBlur: ComponentFramework.PropertyTypes.TwoOptionsProperty;
     MultiSelect: ComponentFramework.PropertyTypes.TwoOptionsProperty;
     RowKey: ComponentFramework.PropertyTypes.StringProperty;

--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -72,6 +72,7 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
     private _resetVersion: number = 0;
     private _fontSize?: number;
     private _themeClass: string = 'ag-theme-balham';
+    private _customThemeCss?: string;
 
     private formatToMinutes(val: unknown): unknown {
         if (val instanceof Date) {
@@ -207,7 +208,9 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
         this._rowKeyField = context.parameters.RowKey.raw || undefined;
         this._readOnly = context.parameters.ReadOnly.raw === true;
         this._fontSize = context.parameters.FontSize.raw !== null ? context.parameters.FontSize.raw : undefined;
-        this._themeClass = context.parameters.ThemeClass.raw || 'ag-theme-balham';
+        const themeInput = context.parameters.ThemeClass.raw || 'balham';
+        this._themeClass = themeInput.startsWith('ag-theme-') ? themeInput : `ag-theme-${themeInput}`;
+        this._customThemeCss = context.parameters.CustomThemeCss.raw || undefined;
         this._showEdited = context.parameters.ShowEdited.raw === true;
         let selectedKeys: string[] | undefined;
         const selectedKeysInput = context.parameters.SelectedRowKeys.raw;
@@ -384,6 +387,7 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                 gridBackgroundColor: context.parameters.GridBackgroundColor.raw || undefined,
                 fontSize: this._fontSize,
                 themeClass: this._themeClass,
+                customThemeCss: this._customThemeCss,
                 enableBlur: context.parameters.EnableBlur.raw === true,
                 multiSelect: this._multiSelect,
                 readOnly: this._readOnly,

--- a/AgGrid/styles/custom.css
+++ b/AgGrid/styles/custom.css
@@ -1,2 +1,5 @@
 @import "~ag-grid-community/styles/ag-grid.css";
+@import "~ag-grid-community/styles/ag-theme-alpine.css";
 @import "~ag-grid-community/styles/ag-theme-balham.css";
+@import "~ag-grid-community/styles/ag-theme-material.css";
+@import "~ag-grid-community/styles/ag-theme-quartz.css";

--- a/README.md
+++ b/README.md
@@ -185,18 +185,20 @@ On Windows, run the PowerShell script:
 ./BuildSolution.ps1
 ```
 
-### Balham theme styling
-The `custom.css` file imports AG Grid's core and Balham theme styles so the theme is bundled with the control:
+### Theme styling
+The `custom.css` file now bundles AG Grid's core styles along with all built-in themes:
 
 ```css
 @import "~ag-grid-community/styles/ag-grid.css";
+@import "~ag-grid-community/styles/ag-theme-alpine.css";
 @import "~ag-grid-community/styles/ag-theme-balham.css";
+@import "~ag-grid-community/styles/ag-theme-material.css";
+@import "~ag-grid-community/styles/ag-theme-quartz.css";
 ```
 
-This theme uses CSS variables for its colors, fonts and spacing. If your grid does not match the examples shown in the [AG Grid Themes guide](https://www.ag-grid.com/javascript-data-grid/themes/), verify that this stylesheet is included in the build output. You can override Balham's variables using the input properties `HeaderColor`, `PaginationColor` and `GridBackgroundColor` or by adding your own CSS rules.
+Select the theme at runtime using the `ThemeClass` input. Provide the theme name only (for example `balham` or `material`) and the control will apply the corresponding `ag-theme-*` class.
 
 ### Custom themes with the AG Grid Theme Builder
 
-The control also supports themes generated with the [AG Grid Theme Builder](https://www.ag-grid.com/theme-builder/).  
-Add the exported CSS file to the `styles` folder (for example `theme-builder.css`) and reference it in the manifest.  
-Use the new `ThemeClass` input property to specify the class name of your custom theme, such as `ag-theme-builder`.
+You can further customize the appearance using CSS from the [AG Grid Theme Builder](https://www.ag-grid.com/theme-builder/).
+Paste the generated CSS into the new `CustomThemeCss` input property. The styles are injected at runtime so you can tweak variables without modifying the manifest.


### PR DESCRIPTION
## Summary
- expose built-in themes via `custom.css`
- add `CustomThemeCss` input and parse theme name
- inject custom theme CSS at runtime
- document using the new theme options

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688a90e2fd6883339a2c9f6d81038e39