### PR TITLE
Fix missing AG Grid themes

### DIFF
--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -12,6 +12,10 @@ import FluentDateTimeCellEditor from './FluentDateTimeCellEditor';
 import FluentDateInput from './FluentDateInput';
 import type { CellEditingStoppedEvent } from 'ag-grid-community';
 import 'ag-grid-community/styles/ag-grid.css'; // Core CSS
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+import 'ag-grid-community/styles/ag-theme-balham.css';
+import 'ag-grid-community/styles/ag-theme-material.css';
+import 'ag-grid-community/styles/ag-theme-quartz.css';
 
 interface EditedCell {
     rowId: string;

--- a/AgGrid/styles/custom.css
+++ b/AgGrid/styles/custom.css
@@ -1,5 +1,1 @@
-@import "~ag-grid-community/styles/ag-grid.css";
-@import "~ag-grid-community/styles/ag-theme-alpine.css";
-@import "~ag-grid-community/styles/ag-theme-balham.css";
-@import "~ag-grid-community/styles/ag-theme-material.css";
-@import "~ag-grid-community/styles/ag-theme-quartz.css";
+/* Add any additional custom CSS for the grid here */

--- a/README.md
+++ b/README.md
@@ -186,14 +186,14 @@ On Windows, run the PowerShell script:
 ```
 
 ### Theme styling
-The `custom.css` file now bundles AG Grid's core styles along with all built-in themes:
+All built-in AG Grid themes are imported directly by the React component:
 
-```css
-@import "~ag-grid-community/styles/ag-grid.css";
-@import "~ag-grid-community/styles/ag-theme-alpine.css";
-@import "~ag-grid-community/styles/ag-theme-balham.css";
-@import "~ag-grid-community/styles/ag-theme-material.css";
-@import "~ag-grid-community/styles/ag-theme-quartz.css";
+```ts
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+import 'ag-grid-community/styles/ag-theme-balham.css';
+import 'ag-grid-community/styles/ag-theme-material.css';
+import 'ag-grid-community/styles/ag-theme-quartz.css';
 ```
 
 Select the theme at runtime using the `ThemeClass` input. Provide the theme name only (for example `balham` or `material`) and the control will apply the corresponding `ag-theme-*` class.


### PR DESCRIPTION
## Summary
- load built-in AG Grid theme CSS directly in the React component so they are bundled with the control
- leave `custom.css` empty for any local tweaks
- update README to clarify theme handling

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688ae4ab12cc8333969deda9692f04f7