### PR TITLE
Handle theme casing

### DIFF
--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -208,8 +208,11 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
         this._rowKeyField = context.parameters.RowKey.raw || undefined;
         this._readOnly = context.parameters.ReadOnly.raw === true;
         this._fontSize = context.parameters.FontSize.raw !== null ? context.parameters.FontSize.raw : undefined;
-        const themeInput = context.parameters.ThemeClass.raw || 'balham';
-        this._themeClass = themeInput.startsWith('ag-theme-') ? themeInput : `ag-theme-${themeInput}`;
+        const themeInputRaw = context.parameters.ThemeClass.raw || 'balham';
+        const themeInput = themeInputRaw.trim().toLowerCase();
+        this._themeClass = themeInput.startsWith('ag-theme-')
+            ? themeInput
+            : `ag-theme-${themeInput}`;
         this._customThemeCss = context.parameters.CustomThemeCss.raw || undefined;
         this._showEdited = context.parameters.ShowEdited.raw === true;
         let selectedKeys: string[] | undefined;

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ import 'ag-grid-community/styles/ag-theme-material.css';
 import 'ag-grid-community/styles/ag-theme-quartz.css';
 ```
 
-Select the theme at runtime using the `ThemeClass` input. Provide the theme name only (for example `balham` or `material`) and the control will apply the corresponding `ag-theme-*` class.
+Select the theme at runtime using the `ThemeClass` input. Provide the theme name only (for example `balham` or `material`) and the control will apply the corresponding `ag-theme-*` class. The value is case-insensitive and leading/trailing spaces are ignored.
 
 ### Custom themes with the AG Grid Theme Builder
 


### PR DESCRIPTION
## Summary
- trim and lowercase `ThemeClass` input before applying
- note that theme names are case-insensitive in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688afb9cf0f48333bf71311f6a961737