### PR TITLE
Add ThemeBase option for AG Grid theming

### DIFF
--- a/AgGrid/ControlManifest.Input.xml
+++ b/AgGrid/ControlManifest.Input.xml
@@ -33,6 +33,10 @@
       <property name="GridBackgroundColor" display-name-key="GridBackgroundColor" of-type="SingleLine.Text" usage="input" default-value="" />
       <property name="FontSize" display-name-key="FontSize" of-type="Decimal" usage="input" default-value="13" />
       <property name="ThemeClass" display-name-key="ThemeClass" of-type="SingleLine.Text" usage="input" default-value="balham" />
+      <!-- Name of the built-in theme object such as 'alpine', 'balham',
+           'material' or 'quartz'. When provided the control passes the
+           corresponding theme object to AgGridReact. -->
+      <property name="ThemeBase" display-name-key="ThemeBase" of-type="SingleLine.Text" usage="input" default-value="" />
       <property name="CustomThemeCss" display-name-key="CustomThemeCss" of-type="SingleLine.TextArea" usage="input" default-value="" />
       <property name="EnableBlur" display-name-key="EnableBlur" of-type="TwoOptions" usage="input" default-value="false" />
     <property name="MultiSelect" display-name-key="MultiSelect" of-type="TwoOptions" usage="input" default-value="true" />

--- a/AgGrid/components/AgGrid.tsx
+++ b/AgGrid/components/AgGrid.tsx
@@ -36,6 +36,11 @@ interface MyAgGridProps {
     gridBackgroundColor?: string;
     fontSize?: number | string;
     themeClass?: string;
+    /**
+     * Optional theme object from ag-grid-community. When provided this is
+     * passed directly to AgGridReact via the `theme` prop.
+     */
+    theme?: unknown;
     customThemeCss?: string;
     enableBlur?: boolean;
     multiSelect?: boolean;
@@ -45,7 +50,7 @@ interface MyAgGridProps {
     resetVersion?: number;
 }
     
-const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selectedRowIds, onSelectionChanged, onCellValueChanged, headerColor, paginationColor, gridBackgroundColor, fontSize, themeClass = 'ag-theme-balham', customThemeCss, enableBlur = false, multiSelect = true, showSelectionToggle = false, readOnly = false, showPagination = true, resetVersion }) => {
+const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selectedRowIds, onSelectionChanged, onCellValueChanged, headerColor, paginationColor, gridBackgroundColor, fontSize, themeClass = 'ag-theme-balham', theme, customThemeCss, enableBlur = false, multiSelect = true, showSelectionToggle = false, readOnly = false, showPagination = true, resetVersion }) => {
     console.log('AG Grid')
     const divClass = themeClass;
     const [autoDefName, setAutoDefName] = useState('');
@@ -366,6 +371,7 @@ const AgGrid: React.FC<MyAgGridProps> = React.memo(({ rowData, columnDefs, selec
                 gridOptions={gridOptions}
                 defaultColDef={defaultColDef}
                 getRowId={getRowId}
+                theme={theme as any}
                 pagination={showPagination}
                 rowSelection={rowSelectionMode}
                 rowMultiSelectWithClick={false}

--- a/AgGrid/generated/ManifestTypes.d.ts
+++ b/AgGrid/generated/ManifestTypes.d.ts
@@ -11,6 +11,7 @@ export interface IInputs {
     GridBackgroundColor: ComponentFramework.PropertyTypes.StringProperty;
     FontSize: ComponentFramework.PropertyTypes.DecimalNumberProperty;
     ThemeClass: ComponentFramework.PropertyTypes.StringProperty;
+    ThemeBase: ComponentFramework.PropertyTypes.StringProperty;
     CustomThemeCss: ComponentFramework.PropertyTypes.StringProperty;
     EnableBlur: ComponentFramework.PropertyTypes.TwoOptionsProperty;
     MultiSelect: ComponentFramework.PropertyTypes.TwoOptionsProperty;

--- a/AgGrid/index.ts
+++ b/AgGrid/index.ts
@@ -3,7 +3,15 @@ import MyAgGrid from './components/AgGrid'
 import React from "react";
 import ReactDOM from 'react-dom';
 import '@fluentui/react/dist/css/fabric.css';
-import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
+import {
+    ModuleRegistry,
+    AllCommunityModule,
+    themeAlpine,
+    themeBalham,
+    themeMaterial,
+    themeQuartz,
+    type Theme
+} from 'ag-grid-community';
 import { toLocalIsoMinutes } from './utils/date';
 
 // Ensure all community grid modules are registered for compatibility with
@@ -73,6 +81,7 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
     private _resetVersion: number = 0;
     private _fontSize?: number;
     private _themeClass: string = 'ag-theme-balham';
+    private _baseTheme?: Theme;
     private _customThemeCss?: string;
 
     private formatToMinutes(val: unknown): unknown {
@@ -215,6 +224,14 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
         this._themeClass = themeInput.startsWith('ag-theme-')
             ? themeInput
             : `ag-theme-${themeInput}`;
+        const baseInput = (context.parameters.ThemeBase.raw || '').trim().toLowerCase();
+        const themeMap: Record<string, Theme> = {
+            alpine: themeAlpine,
+            balham: themeBalham,
+            material: themeMaterial,
+            quartz: themeQuartz
+        };
+        this._baseTheme = themeMap[baseInput];
         this._customThemeCss = context.parameters.CustomThemeCss.raw || undefined;
         this._showEdited = context.parameters.ShowEdited.raw === true;
         let selectedKeys: string[] | undefined;
@@ -392,6 +409,7 @@ export class AgGrid implements ComponentFramework.StandardControl<IInputs, IOutp
                 gridBackgroundColor: context.parameters.GridBackgroundColor.raw || undefined,
                 fontSize: this._fontSize,
                 themeClass: this._themeClass,
+                theme: this._baseTheme,
                 customThemeCss: this._customThemeCss,
                 enableBlur: context.parameters.EnableBlur.raw === true,
                 multiSelect: this._multiSelect,

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ import 'ag-grid-community/styles/ag-theme-quartz.css';
 
 Select the theme at runtime using the `ThemeClass` input. Provide the theme name only (for example `balham` or `material`) and the control will apply the corresponding `ag-theme-*` class. The value is case-insensitive and leading/trailing spaces are ignored.
 
+You can also choose a built-in theme object via the `ThemeBase` input. When set to one of `alpine`, `balham`, `material` or `quartz` the corresponding theme is passed to `AgGridReact` through the `theme` prop. This enables dynamic theming with the new AG Grid style API.
+
 ### Custom themes with the AG Grid Theme Builder
 
 You can further customize the appearance using CSS from the [AG Grid Theme Builder](https://www.ag-grid.com/theme-builder/).


### PR DESCRIPTION
## Summary
- allow passing a theme object to `AgGridReact`
- add `ThemeBase` input property
- document new theme option

## Testing
- `npm run refreshTypes`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688b042300648333a35f14d52dec0a88