### PR TITLE
Fix solution build script path handling

### DIFF
--- a/BuildSolution.ps1
+++ b/BuildSolution.ps1
@@ -5,7 +5,7 @@
 $ErrorActionPreference = 'Stop'
 
 # automatically determine the absolute path to the repository root
-$rootDir = (Get-Location).Path
+$rootDir = (Get-Item -Path (Get-Location)).FullName
 
 # create and enter project directory
 if(-not (Test-Path 'AgGridPCF')){

--- a/BuildSolution.sh
+++ b/BuildSolution.sh
@@ -4,7 +4,7 @@
 set -e
 
 # automatically determine the absolute path to the repository root
-ROOT_DIR="$(pwd)"
+ROOT_DIR="$(realpath "$PWD")"
 
 # create and enter project directory
 if [ ! -d AgGridPCF ]; then


### PR DESCRIPTION
## Summary
- ensure BuildSolution.sh uses the canonical repo path
- update BuildSolution.ps1 to resolve the repo path

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688c2174d86083339cd8c8022cd9b0d6